### PR TITLE
add pollTimeout parameter and set default to 5 minutes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,6 +25,7 @@ import (
 var (
 	myFqdn   = kingpin.Flag("fqdn", "FQDN to register with").Default(fqdn.Get()).String()
 	proxyURL = kingpin.Flag("proxy-url", "Push proxy to talk to.").Required().String()
+	pollTimeout = kingpin.Flag("poll.timeout", "After how long a poll expires.").Default("5m").Duration()
 )
 
 type Coordinator struct {
@@ -104,7 +105,7 @@ func (c *Coordinator) doPush(resp *http.Response, origRequest *http.Request, cli
 }
 
 func loop(c Coordinator) {
-	client := &http.Client{}
+	client := &http.Client{Timeout: *pollTimeout}
 	base, err := url.Parse(*proxyURL)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "Error parsing url:", "err", err)


### PR DESCRIPTION
This will set a timeout for the poll connection between client and server.
This helps to recover after a outage of the prometheus server and therefore from a lack of scraping.

Fixes [Issue #10](https://github.com/RobustPerception/PushProx/issues/10)